### PR TITLE
Fix the startup error

### DIFF
--- a/src/emqx_auth_username.app.src
+++ b/src/emqx_auth_username.app.src
@@ -3,10 +3,9 @@
               {vsn,"git"},
               {modules,[]},
               {registered,[]},
-              {applications, [kernel, stdlib, emqx]},
+              {applications, [kernel, stdlib]},
               {mod,{emqx_auth_username_app, []}},
               {env,[]},
-              {mod, {emqx_auth_username_app, []}},
               {licenses, ["Apache-2.0"]},
               {links, ["Github", "https://github.com/emqx/emqx-auth-username"]}
              ]}.


### PR DESCRIPTION
Prior to this change, the app.src of emqx_auth_username include emqx
which may be trigger the bug of the startup of the emqx_auth_username.

This change fix the issue https://github.com/emqx/emqx-auth-username/issues/57