### PR TITLE
Add encrypted options

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ etc/emqx_auth_username.conf:
 ```
 ##auth.user.$N.username = admin
 ##auth.user.$N.password = public
+
+## Password hash.
+##
+## Value: plain | md5 | sha | sha256 
+auth.user.password_hash = md5
 ```
 
 Load the Plugin

--- a/etc/emqx_auth_username.conf
+++ b/etc/emqx_auth_username.conf
@@ -9,3 +9,8 @@
 ##auth.user.2.password = public
 ##auth.user.3.username = name~!@#$%^&*()_+
 ##auth.user.3.password = pwsswd~!@#$%^&*()_+
+
+## Password hash.
+##
+## Value: plain | md5 | sha | sha256 
+auth.user.password_hash = md5

--- a/include/emqx_auth_username.hrl
+++ b/include/emqx_auth_username.hrl
@@ -1,0 +1,1 @@
+-define(APP, emqx_auth_username).

--- a/priv/emqx_auth_username.schema
+++ b/priv/emqx_auth_username.schema
@@ -9,6 +9,10 @@
   {datatype, string}
 ]}.
 
+{mapping, "auth.user.password_hash", "emqx_auth_username.password_hash", [
+  {datatype, atom}
+]}.
+
 {translation, "emqx_auth_username.userlist", fun(Conf) ->
   Userlist = cuttlefish_variable:filter_by_prefix("auth.user", Conf),
   lists:foldl(

--- a/src/emqx_auth_username.erl
+++ b/src/emqx_auth_username.erl
@@ -146,4 +146,5 @@ hash(Password, SaltBin, HashType) ->
     emqx_passwd:hash(HashType, <<SaltBin/binary, Password/binary>>).
 
 salt() ->
-    emqx_time:seed(), Salt = rand:uniform(16#ffffffff), <<Salt:32>>.
+    rand:seed(exsplus, erlang:timestamp()),
+    Salt = rand:uniform(16#ffffffff), <<Salt:32>>.

--- a/src/emqx_auth_username.erl
+++ b/src/emqx_auth_username.erl
@@ -27,6 +27,7 @@
 
 -define(TAB, ?MODULE).
 -record(?TAB, {username, password}).
+-record(state, {hash_type}).
 
 %%-----------------------------------------------------------------------------
 %% CLI
@@ -70,7 +71,7 @@ is_enabled() ->
 %% @doc Add User
 -spec(add_user(binary(), binary()) -> ok | {error, any()}).
 add_user(Username, Password) ->
-    User = #?TAB{username = Username, password = hash(Password)},
+    User = #?TAB{username = Username, password = encrypted_data(Password)},
     ret(mnesia:transaction(fun insert_user/1, [User])).
 
 insert_user(User = #?TAB{username = Username}) ->
@@ -106,23 +107,24 @@ all_users() -> mnesia:dirty_all_keys(?TAB).
 %% emqx_auth_mod callbacks
 %%-----------------------------------------------------------------------------
 
-init(Userlist) ->
+init({Userlist, HashType}) ->
+    State = #state{hash_type = HashType},
     ok = ekka_mnesia:create_table(?TAB, [
             {disc_copies, [node()]},
             {attributes, record_info(fields, ?TAB)}]),
     ok = ekka_mnesia:copy_table(?TAB, disc_copies),
     ok = lists:foreach(fun add_default_user/1, Userlist),
-    {ok, undefined}.
+    {ok, State}.
 
 check(#{username := undefined}, _Password, _Opts) ->
     {error, username_undefined};
 check(_Credentials, undefined, _Opts) ->
     {error, password_undefined};
-check(#{username := Username}, Password, _Opts) ->
+check(#{username := Username}, Password, #state{hash_type = HashType}) ->
     case mnesia:dirty_read(?TAB, Username) of
         [] -> ignore;
         [#?TAB{password = <<Salt:4/binary, Hash/binary>>}] ->
-            case Hash =:= md5_hash(Salt, Password) of
+            case Hash =:= hash(Password, Salt, HashType) of
                 true -> ok;
                 false -> {error, password_error}
             end
@@ -135,12 +137,13 @@ description() ->
 %% Internal functions
 %%-----------------------------------------------------------------------------
 
-hash(Password) ->
-    SaltBin = salt(), <<SaltBin/binary, (md5_hash(SaltBin, Password))/binary>>.
+encrypted_data(Password) ->
+    HashType = application:get_env(emqx_auth_username, password_hash, md5),
+    SaltBin = salt(),
+    <<SaltBin/binary, (hash(Password, SaltBin, HashType))/binary>>.
 
-md5_hash(SaltBin, Password) ->
-    erlang:md5(<<SaltBin/binary, Password/binary>>).
+hash(Password, SaltBin, HashType) ->
+    emqx_passwd:hash(HashType, <<SaltBin/binary, Password/binary>>).
 
 salt() ->
     emqx_time:seed(), Salt = rand:uniform(16#ffffffff), <<Salt:32>>.
-

--- a/src/emqx_auth_username_app.erl
+++ b/src/emqx_auth_username_app.erl
@@ -23,9 +23,10 @@
 -define(APP, emqx_auth_username).
 
 start(_Type, _Args) ->
-    emqx_ctl:register_command(users, {?APP, cli}, []),
     Userlist = application:get_env(?APP, userlist, []),
-    emqx_access_control:register_mod(auth, ?APP, Userlist),
+    HashType = application:get_env(?APP, password_hash, md5),
+    emqx_access_control:register_mod(auth, ?APP, {Userlist, HashType}),
+    emqx_auth_username_cfg:register(),
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
 stop(_State) ->

--- a/src/emqx_auth_username_cfg.erl
+++ b/src/emqx_auth_username_cfg.erl
@@ -1,0 +1,80 @@
+%% Copyright (c) 2018 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module (emqx_auth_username_cfg).
+
+-include("emqx_auth_username.hrl").
+
+-export ([register/0, unregister/0]).
+
+register() ->
+    clique_config:load_schema([code:priv_dir(?APP)], ?APP),
+    register_formatter(),
+    register_config().
+
+unregister() ->
+    unregister_formatter(),
+    unregister_config(),
+    clique_config:unload_schema(?APP).
+
+register_formatter() ->
+    [clique:register_formatter(cuttlefish_variable:tokenize(Key),
+     fun formatter_callback/2) || Key <- keys()].
+
+formatter_callback([_, _, "password_hash"], Params) when is_atom(Params) ->
+    Params;
+formatter_callback([_, _, "password_hash"], Params) when is_tuple(Params) ->
+    format(tuple_to_list(Params));
+formatter_callback([_, _, Key], Params) ->
+    proplists:get_value(list_to_atom(Key), Params).
+
+unregister_formatter() ->
+    [clique:unregister_formatter(cuttlefish_variable:tokenize(Key)) || Key <- keys()].
+
+register_config() ->
+    Keys = keys(),
+    [clique:register_config(Key , fun config_callback/2) || Key <- Keys],
+    clique:register_config_whitelist(Keys, ?APP).
+
+config_callback([_, _, "password_hash"], Value0) ->
+    Value = parse_password_hash(Value0),
+    application:set_env(?APP, password_hash, Value),
+    " successfully\n";
+config_callback([_, _, Key0], Value) ->
+    Key = list_to_atom(Key0),
+    {ok, Env} = application:get_env(?APP, server),
+    application:set_env(?APP, server, lists:keyreplace(Key, 1, Env, {Key, Value})),
+    " successfully\n".
+
+unregister_config() ->
+    Keys = keys(),
+    [clique:unregister_config(Key) || Key <- Keys],
+    clique:unregister_config_whitelist(Keys, ?APP).
+
+keys() ->
+    ["auth.user.password_hash"].
+
+format(Value) ->
+    format(Value, "").
+format([Head], Acc) ->
+    lists:concat([Acc, Head]);
+format([Head | Tail], Acc) ->
+    format(Tail, Acc ++ lists:concat([Head, ","])).
+
+parse_password_hash(Value) ->
+    case string:tokens(Value, ",") of
+          [Hash]           -> list_to_atom(Hash);
+          _                -> plain
+    end.
+


### PR DESCRIPTION
 Description: :
Add a encryption options about encryption of passwords. Supported encryption modes include: plain md5 sha sha256 ,
`## Value: plain | md5 | sha | sha256 ##auth.client.password_hash = md5`