### PR TITLE
Modify default value for password hash 

### DIFF
--- a/etc/emqx_auth_username.conf
+++ b/etc/emqx_auth_username.conf
@@ -13,4 +13,4 @@
 ## Password hash.
 ##
 ## Value: plain | md5 | sha | sha256 
-auth.user.password_hash = md5
+auth.user.password_hash = sha256

--- a/priv/emqx_auth_username.schema
+++ b/priv/emqx_auth_username.schema
@@ -10,7 +10,7 @@
 ]}.
 
 {mapping, "auth.user.password_hash", "emqx_auth_username.password_hash", [
-  {default, md5},
+  {default, sha256},
   {datatype, {enum, [plain, md5, sha, sha256]}}
 ]}.
 

--- a/src/emqx_auth_username_app.erl
+++ b/src/emqx_auth_username_app.erl
@@ -25,7 +25,7 @@
 start(_Type, _Args) ->
     emqx_ctl:register_command(users, {?APP, cli}, []),
     Userlist = application:get_env(?APP, userlist, []),
-    HashType = application:get_env(?APP, password_hash, md5),
+    HashType = application:get_env(?APP, password_hash, sha256),
     emqx_access_control:register_mod(auth, ?APP, {Userlist, HashType}),
     emqx_auth_username_cfg:register(),
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).


### PR DESCRIPTION
Modify default value for password hash  
use `sha256` instead of `md5`
