### PR TITLE
Add the username CURD HTTP API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,10 @@ PROJECT_DESCRIPTION = EMQ X Authentication with Username/Password
 CUR_BRANCH := $(shell git branch | grep -e "^*" | cut -d' ' -f 2)
 BRANCH := $(if $(filter $(CUR_BRANCH), master develop), $(CUR_BRANCH), develop)
 
-DEPS = emqx_passwd clique
-dep_emqx_passwd = git-emqx https://github.com/emqx/emqx-passwd v1.0
-dep_clique      = git-emqx https://github.com/emqx/clique v0.3.11
+DEPS = emqx_management emqx_passwd clique
+dep_emqx_management = git-emqx https://github.com/emqx/emqx-management $(BRANCH)
+dep_emqx_passwd     = git-emqx https://github.com/emqx/emqx-passwd v1.0
+dep_clique          = git-emqx https://github.com/emqx/clique v0.3.11
 
 BUILD_DEPS = emqx cuttlefish
 dep_emqx = git-emqx https://github.com/emqx/emqx $(BRANCH)

--- a/src/emqx_auth_username.erl
+++ b/src/emqx_auth_username.erl
@@ -23,7 +23,7 @@
 -export([is_enabled/0]).
 -export([add_user/2, update_password/2, remove_user/1, lookup_user/1, all_users/0]).
 %% emqx_auth callbacks
--export([init/1, check/3, description/0]).
+-export([init/1, check/3, unwarp_salt/1, description/0]).
 
 -define(TAB, ?MODULE).
 -record(?TAB, {username, password}).
@@ -148,6 +148,9 @@ check(#{username := Username}, Password, #state{hash_type = HashType}) ->
                 false -> {error, password_error}
             end
     end.
+
+unwarp_salt(<<_Salt:4/binary, HashPasswd/binary>>) ->
+    HashPasswd.
 
 description() ->
     "Username password Authentication Module".

--- a/src/emqx_auth_username_api.erl
+++ b/src/emqx_auth_username_api.erl
@@ -18,25 +18,25 @@
 
 -rest_api(#{name   => list_username,
             method => 'GET',
-            path   => "/emqx_auth_username/list/",
+            path   => "/emqx_auth_username/list",
             func   => list,
             descr  => "List available username in the cluster"}).
 
 -rest_api(#{name   => add_username,
             method => 'POST',
-            path   => "/emqx_auth_username/add/",
+            path   => "/emqx_auth_username/add",
             func   => add,
             descr  => "Add username in the cluster"}).
 
 -rest_api(#{name   => update_username,
             method => 'PUT',
-            path   => "/emqx_auth_username/:bin:username/",
+            path   => "/emqx_auth_username/:bin:username",
             func   => update,
             descr  => "Update username in the cluster"}).
 
 -rest_api(#{name   => delete_username,
             method => 'DELETE',
-            path   => "/emqx_auth_username/:bin:username/",
+            path   => "/emqx_auth_username/:bin:username",
             func   => delete,
             descr  => "Delete username in the cluster"}).
 

--- a/src/emqx_auth_username_api.erl
+++ b/src/emqx_auth_username_api.erl
@@ -14,13 +14,87 @@
 
 -module(emqx_auth_username_api).
 
+-import(proplists, [get_value/2]).
+
 -rest_api(#{name   => list_username,
+            method => 'GET',
+            path   => "/emqx_auth_username/list/",
+            func   => list,
+            descr  => "List available username in the cluster"}).
+
+-rest_api(#{name   => add_username,
             method => 'POST',
             path   => "/emqx_auth_username/add/",
             func   => add,
-            descr  => "A add username in the cluster"}).
+            descr  => "Add username in the cluster"}).
 
--export([add/2]).
+-rest_api(#{name   => update_username,
+            method => 'PUT',
+            path   => "/emqx_auth_username/:bin:username/",
+            func   => update,
+            descr  => "Update username in the cluster"}).
 
-add(_Bindings, _Params) ->
-    {ok, [{code, 200}, {data, []}]}.
+-rest_api(#{name   => delete_username,
+            method => 'DELETE',
+            path   => "/emqx_auth_username/:bin:username/",
+            func   => delete,
+            descr  => "Delete username in the cluster"}).
+
+-export([list/2, add/2, update/2, delete/2]).
+
+list(_Bindings, _Params) ->
+    return({ok, emqx_auth_username:all_users()}).
+
+add(_Bindings, Params) ->
+    Username = get_value(<<"username">>, Params),
+    Password = get_value(<<"password">>, Params),
+    case validate([username, password], [Username, Password]) of
+        ok ->
+            case emqx_auth_username:add_user(Username, Password) of
+                ok  -> return();
+                Err -> return(Err)
+            end;
+        Err -> return(Err)
+    end.
+
+update(#{username := Username}, Params) ->
+    Password = get_value(<<"password">>, Params),
+    case validate([password], [Password]) of
+        ok ->
+            case emqx_auth_username:update_password(Username, Password) of
+                ok  -> return();
+                Err -> return(Err)
+            end;
+        Err -> return(Err)
+    end.
+
+delete(#{username := Username}, _) ->
+    ok = emqx_auth_username:remove_user(Username),
+    return().
+
+%%------------------------------------------------------------------------------
+%% Interval Funcs
+%%------------------------------------------------------------------------------
+
+return() ->
+    emqx_mgmt:return().
+return(R) ->
+    emqx_mgmt:return(R).
+
+validate([], []) ->
+    ok;
+validate([K|Keys], [V|Values]) ->
+   case validation(K, V) of
+       false -> {error, K};
+       true  -> validate(Keys, Values)
+   end.
+
+validation(username, V) when is_binary(V)
+                     andalso byte_size(V) > 0 ->
+    true;
+validation(password, V) when is_binary(V)
+                     andalso byte_size(V) > 0 ->
+    true;
+validation(_, _) ->
+    false.
+

--- a/src/emqx_auth_username_api.erl
+++ b/src/emqx_auth_username_api.erl
@@ -18,25 +18,25 @@
 
 -rest_api(#{name   => list_username,
             method => 'GET',
-            path   => "/emqx_auth_username/list",
+            path   => "/auth_username",
             func   => list,
             descr  => "List available username in the cluster"}).
 
 -rest_api(#{name   => add_username,
             method => 'POST',
-            path   => "/emqx_auth_username/add",
+            path   => "/auth_username",
             func   => add,
             descr  => "Add username in the cluster"}).
 
 -rest_api(#{name   => update_username,
             method => 'PUT',
-            path   => "/emqx_auth_username/:bin:username",
+            path   => "/auth_username/:bin:username",
             func   => update,
             descr  => "Update username in the cluster"}).
 
 -rest_api(#{name   => delete_username,
             method => 'DELETE',
-            path   => "/emqx_auth_username/:bin:username",
+            path   => "/auth_username/:bin:username",
             func   => delete,
             descr  => "Delete username in the cluster"}).
 


### PR DESCRIPTION
Try to fix https://github.com/emqx/emqx/issues/2200

In the current implementation, we can add or management by the HTTP interface:
```
## Add a username
$ curl -v --user appname:appsecret -H "Content-Type: application/json" -d "{username: "user1", password:"pwd"}" SERVER:8080/api/v3/auth_username
```