### PR TITLE
Restore default usernames in conf

### DIFF
--- a/etc/emqx_auth_username.conf
+++ b/etc/emqx_auth_username.conf
@@ -2,6 +2,14 @@
 ## Username Authentication Plugin
 ##--------------------------------------------------------------------
 
+## Examples:
+##auth.user.1.username = admin
+##auth.user.1.password = public
+##auth.user.2.username = feng@emqtt.io
+##auth.user.2.password = public
+##auth.user.3.username = name~!@#$%^&*()_+
+##auth.user.3.password = pwsswd~!@#$%^&*()_+
+
 ## Password hash.
 ##
 ## Value: plain | md5 | sha | sha256 

--- a/priv/emqx_auth_username.schema
+++ b/priv/emqx_auth_username.schema
@@ -6,3 +6,21 @@
   {datatype, {enum, [plain, md5, sha, sha256]}}
 ]}.
 
+{mapping, "auth.user.$id.username", "emqx_auth_username.userlist", [
+  {datatype, string}
+]}.
+
+{mapping, "auth.user.$id.password", "emqx_auth_username.userlist", [
+  {datatype, string}
+]}.
+
+{translation, "emqx_auth_username.userlist", fun(Conf) ->
+  Userlist = cuttlefish_variable:filter_by_prefix("auth.user", Conf),
+  lists:foldl(
+    fun({["auth", "user", Id, "username"], Username}, AccIn) ->
+        [{Username, cuttlefish:conf_get("auth.user." ++ Id ++ ".password", Conf)} | AccIn];
+       (_, AccIn) ->
+        AccIn
+       end, [], Userlist)
+end}.
+

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,3 +1,5 @@
+%% -*-: erlang -*-
+
 CONFIG1 = case os:getenv("TRAVIS") of
               "true" ->
                   JobId = os:getenv("TRAVIS_JOB_ID"),

--- a/src/emqx_auth_username.erl
+++ b/src/emqx_auth_username.erl
@@ -34,7 +34,7 @@
 -export([unwrap_salt/1]).
 
 %% Auth callbacks
--export([ init/0
+-export([ init/1
         , register_metrics/0
         , check/3
         , description/0
@@ -96,6 +96,7 @@ hint() ->
 is_enabled() ->
     lists:member(?TAB, mnesia:system_info(tables)).
 
+
 %% @doc Add User
 -spec(add_user(binary(), binary()) -> ok | {error, any()}).
 add_user(Username, Password) ->
@@ -144,11 +145,16 @@ unwrap_salt(<<_Salt:4/binary, HashPasswd/binary>>) ->
 %% Auth callbacks
 %%--------------------------------------------------------------------
 
-init() ->
+init(DefaultUsers) ->
     ok = ekka_mnesia:create_table(?TAB, [
             {disc_copies, [node()]},
             {attributes, record_info(fields, ?TAB)}]),
+    ok = lists:foreach(fun add_default_user/1, DefaultUsers),
     ok = ekka_mnesia:copy_table(?TAB, disc_copies).
+
+%% @private
+add_default_user({Username, Password}) ->
+    add_user(iolist_to_binary(Username), iolist_to_binary(Password)).
 
 -spec(register_metrics() -> ok).
 register_metrics() ->

--- a/src/emqx_auth_username_app.erl
+++ b/src/emqx_auth_username_app.erl
@@ -34,7 +34,8 @@ start(_Type, _Args) ->
     HashType = application:get_env(?APP, password_hash, sha256),
     Params = #{hash_type => HashType},
     emqx:hook('client.authenticate', fun emqx_auth_username:check/3, [Params]),
-    ok = emqx_auth_username:init(),
+    DefaultUsers = application:get_env(?APP, userlist, []),
+    ok = emqx_auth_username:init(DefaultUsers),
     emqx_auth_username_cfg:register(),
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 

--- a/test/emqx_auth_username_SUITE.erl
+++ b/test/emqx_auth_username_SUITE.erl
@@ -14,6 +14,7 @@
 
 -module(emqx_auth_username_SUITE).
 
+-compile(nowarn_export_all).
 -compile(export_all).
 
 -import(proplists, [get_value/2]).
@@ -26,11 +27,7 @@
 -define(TAB, emqx_auth_username).
 
 all() ->
-    [{group, emqx_auth_username}].
-
-groups() ->
-    [{emqx_auth_username, [sequence],
-      [t_managing, t_rest_api, t_cli]}].
+    emqx_ct:all(?MODULE).
 
 init_per_suite(Config) ->
     emqx_ct_helpers:start_apps([emqx_auth_username], fun set_special_configs/1),
@@ -54,6 +51,8 @@ set_special_configs(_App) ->
 %%------------------------------------------------------------------------------
 
 t_managing(_Config) ->
+    clean_all_users(),
+
     ok = emqx_auth_username:add_user(<<"test_username">>, <<"password">>),
     [{?TAB, <<"test_username">>, _HashedPass}] =
         emqx_auth_username:lookup_user(<<"test_username">>),
@@ -68,6 +67,8 @@ t_managing(_Config) ->
            anonymous := true }} = emqx_access_control:authenticate(User1).
 
 t_rest_api(_Config) ->
+    clean_all_users(),
+
     Username = <<"username">>,
     Password = <<"password">>,
     Password1 = <<"password1">>,
@@ -99,13 +100,12 @@ t_rest_api(_Config) ->
            anonymous := true}} = emqx_access_control:authenticate(User#{password => Password}).
 
 t_cli(_Config) ->
-    [ mnesia:dirty_delete({emqx_auth_username, Username}) ||  Username <- mnesia:dirty_all_keys(emqx_auth_username)],
-    emqx_auth_username:cli(["add", "username", "password"]),
+    clean_all_users(),
 
+    emqx_auth_username:cli(["add", "username", "password"]),
     ?assertEqual(true, match_password(<<"username">>, <<"password">>)),
 
     emqx_auth_username:cli(["update", "username", "newpassword"]),
-
     ?assertEqual(true, match_password(<<"username">>, <<"newpassword">>)),
 
     emqx_auth_username:cli(["del", "username"]),
@@ -116,9 +116,41 @@ t_cli(_Config) ->
     2 = length(UserList),
     emqx_auth_username:cli(usage).
 
+t_conf_not_override_existed(_) ->
+    clean_all_users(),
+
+    Username = <<"username">>,
+    Password = <<"password">>,
+    NPassword = <<"password1">>,
+    User = #{username => Username},
+
+    application:stop(emqx_auth_username),
+    application:set_env(emqx_auth_username, userlist, [{Username, Password}]),
+    application:ensure_all_started(emqx_auth_username),
+
+    {ok, _} = emqx_access_control:authenticate(User#{password => Password}),
+    emqx_auth_username:cli(["update", Username, NPassword]),
+
+    {error, _} = emqx_access_control:authenticate(User#{password => Password}),
+    {ok, _} = emqx_access_control:authenticate(User#{password => NPassword}),
+
+    application:stop(emqx_auth_username),
+    application:ensure_all_started(emqx_auth_username),
+    {ok, _} = emqx_access_control:authenticate(User#{password => NPassword}),
+
+    ?assertEqual(return(),
+                 emqx_auth_username_api:update(rest_binding(Username), rest_params(Password))),
+    application:stop(emqx_auth_username),
+    application:ensure_all_started(emqx_auth_username),
+    {ok, _} = emqx_access_control:authenticate(User#{password => Password}).
+
 %%------------------------------------------------------------------------------
 %% Helpers
 %%------------------------------------------------------------------------------
+
+clean_all_users() ->
+    [ mnesia:dirty_delete({emqx_auth_username, Username})
+      || Username <- mnesia:dirty_all_keys(emqx_auth_username)].
 
 match_password(Username, PlainPassword) ->
     HashType = application:get_env(emqx_auth_username, password_hash, sha256),


### PR DESCRIPTION
After v3.1-rc.2, we remove the default usernames in conf. It's a mistake decision, which brings a lot of trouble to integrate and deploy with other systems.

So, Maybe we should restore those changes